### PR TITLE
Removing message.json from container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .env*
 Dockerfile*
 docker-compose*
+message.json

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -13,6 +13,7 @@ services:
     volumes:
       - './:/home/etdadm'
       - '/tmp/etd_dash_data/in:/home/etdadm/data/in'
+      - 'message.json:/home/etdadmin/message.json'
     env_file:
       - '.env'
     ports:


### PR DESCRIPTION
Mounting the message.json to the integration test container instead of embedding it within the container so that it can be modified per instance (eg - turn dash off for prod).

Deployed to dev and succeeded