### PR TITLE
ETD-285

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -19,7 +19,7 @@ jobs:
         run: git checkout ${{ env.BRANCH }}
               
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,14 +1,20 @@
 import os
 import click
+import logging
+import traceback
+from logging.handlers import TimedRotatingFileHandler
 from flask import Flask, current_app
-
 # Import custom modules from the local project
 # Import API resources
 from . import resources
 
+LOG_FILE_BACKUP_COUNT = 1
+LOG_ROTATION = "midnight"
+
 
 # App factory
 def create_app():
+    configure_logger()
     # Create and configure the app
     app = Flask(__name__, instance_relative_config=True)
     # App config
@@ -21,3 +27,22 @@ def create_app():
     resources.define_resources(app)
 
     return app
+
+
+def configure_logger():
+    log_level = os.getenv("LOG_LEVEL", "DEBUG")
+    log_dir = os.getenv("LOG_DIR", "/home/etdadm/logs")
+    log_file_path = os.path.join(log_dir, "int_tests.log")
+    formatter = logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+    file_handler = TimedRotatingFileHandler(
+        filename=log_file_path,
+        when=LOG_ROTATION,
+        backupCount=LOG_FILE_BACKUP_COUNT
+    )
+
+    logger = logging.getLogger('etd_int_tests')
+    logger.addHandler(file_handler)
+    file_handler.setFormatter(formatter)
+    logger.setLevel(log_level)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -30,7 +30,7 @@ def create_app():
 
 
 def configure_logger():
-    log_level = os.getenv("LOG_LEVEL", "DEBUG")
+    log_level = os.getenv("APP_LOG_LEVEL", "INFO")
     log_dir = os.getenv("LOG_DIR", "/home/etdadm/logs")
     log_file_path = os.path.join(log_dir, "int_tests.log")
     formatter = logging.Formatter(

--- a/app/tests/etd_dais_end_to_end.py
+++ b/app/tests/etd_dais_end_to_end.py
@@ -4,28 +4,12 @@ import shutil
 from datetime import datetime
 import requests
 import logging
-from logging.handlers import TimedRotatingFileHandler
-
-LOG_FILE_BACKUP_COUNT = 1
-LOG_ROTATION = "midnight"
-log_level = os.getenv("LOG_LEVEL", "DEBUG")
-log_dir = os.getenv("LOG_DIR", "/home/etdadm/logs")
-log_file_path = os.path.join(log_dir, "int_tests.log")
-formatter = logging.Formatter(
-    '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-
-file_handler = TimedRotatingFileHandler(
-    filename=log_file_path,
-    when=LOG_ROTATION,
-    backupCount=LOG_FILE_BACKUP_COUNT
-)
-logger = logging.getLogger()
-logger.addHandler(file_handler)
-file_handler.setFormatter(formatter)
-logger.setLevel(log_level)
 
 
 class ETDDAISEndToEnd():
+
+    def __init__(self):
+        self.logger = logging.getLogger('etd_int_tests')
 
     def end_to_end_test(self, content_model=None):
         result = {"num_failed": 0,
@@ -78,14 +62,14 @@ class ETDDAISEndToEnd():
         dest_path = os.path.join(dest_dir, content_model
                                  + "_submission_integration_test")
         os.makedirs(dest_path, exist_ok=True)
-        logger.debug("Test Path: " + test_path)
-        logger.debug("Dest Path: " + dest_path)
+        self.logger.debug("Test Path: " + test_path)
+        self.logger.debug("Dest Path: " + dest_path)
         try:
             files = os.listdir(test_path)
 
             for file_name in files:
                 dest_path = os.path.join(dest_path, file_name)
-                logger.debug("File Dest Path: " + dest_path)
+                self.logger.debug("File Dest Path: " + dest_path)
                 shutil.copy(os.path.join(test_path, file_name), dest_path)
         except Exception:
             return False

--- a/app/tests/etd_dash_service_checks.py
+++ b/app/tests/etd_dash_service_checks.py
@@ -44,7 +44,7 @@ class ETDDashServiceChecks():
         client = Celery('app')
         client.config_from_object('celeryconfig')
 
-        logger.info(">>> Reading message file")
+        logger.info(">>> Read message file")
         messagefile = os.environ.get('MESSAGE_FILE', "message.json")
         with open(messagefile) as f:
             messagejson = f.read()
@@ -70,6 +70,7 @@ class ETDDashServiceChecks():
                     result["info"] = {"Proquest Dropbox sftp failed":
                                       {"status_code": 500,
                                        "text": str(err)}}
+                    logger.error(str(err))
 
                 # 3. send the test object to dash
                 logger.info(">>> Submit test object to dash")
@@ -92,6 +93,7 @@ class ETDDashServiceChecks():
                                        "url": rest_url,
                                        "count": count,
                                        "text": resp_text}}
+                    logger.error("Count is not 1: " + resp_text)
                 # 5. cleanup the test object from the filesystem
                 logger.info(">>> Clean up test object")
                 self.cleanup_test_object()
@@ -105,6 +107,7 @@ class ETDDashServiceChecks():
                     result["info"] = {"Proquest Dropbox sftp failed":
                                       {"status_code": 500,
                                        "text": str(err)}}
+                    logger.error(str(err))
                 client.send_task(name="etd-dash-service.tasks.send_to_dash",
                                  args=[message], kwargs={},
                                  queue=incoming_queue)
@@ -121,6 +124,7 @@ class ETDDashServiceChecks():
                                        "url": rest_url,
                                        "count": count,
                                        "text": resp_text}}
+                    logger.error("Count is 2: " + resp_text)
 
                 # 8. delete the test object from dash
                 logger.info(">>> Delete duplicate test object from dash")
@@ -141,6 +145,7 @@ class ETDDashServiceChecks():
                                            "uuid": uuid,
                                            "session_key": session_key,
                                            "text": "Delete failed"}}
+                        logger.error("Delete failed: " + response.text)
                 # 8. cleanup the test object from the filesystem
                 logger.info(">>> Clean up duplicate test object")
                 self.cleanup_test_object()

--- a/app/tests/etd_dash_service_checks.py
+++ b/app/tests/etd_dash_service_checks.py
@@ -203,13 +203,12 @@ class ETDDashServiceChecks():
         with pysftp.Connection(host=remoteSite,
                                username=remoteUser,
                                private_key=private_key) as sftp:
+            # remove any existing test object
             if sftp.exists(f"{archiveDir}/{zipFile}"):
-                try:
-                    sftp.remove(f"{archiveDir}/{zipFile}")
-                    sftp.put(f"./testdata/{zipFile}",
-                             f"{incomingDir}/{newZipFile}")
-                except Exception as err:
-                    logger.error(f"SFTP error: {err}")
-            # the file doesn't exist, log error.
-            else:
-                logger.error(f"{archiveDir}/{zipFile} does not exist.")
+                sftp.remove(f"{archiveDir}/{zipFile}")
+            # sftp test object to incoming dir
+            try:
+                sftp.put(f"./testdata/{zipFile}",
+                         f"{incomingDir}/{newZipFile}")
+            except Exception as err:
+                logger.error(f"SFTP error: {err}")

--- a/app/tests/etd_dash_service_checks.py
+++ b/app/tests/etd_dash_service_checks.py
@@ -39,7 +39,7 @@ class ETDDashServiceChecks():
 
                 # 2. put the test object in the dropbox
                 try:
-                    self.sftp_test_object()
+                    self.sftp_test_object("999999")
                 except Exception as err:
                     result["num_failed"] += 1
                     result["tests_failed"].append("SFTP")
@@ -70,7 +70,7 @@ class ETDDashServiceChecks():
                 self.cleanup_test_object()
                 # 6. put the test object in the dropbox for a second time
                 try:
-                    self.sftp_test_object()
+                    self.sftp_test_object("999999")
                 except Exception as err:
                     result["num_failed"] += 1
                     result["tests_failed"].append("SFTP")
@@ -155,7 +155,7 @@ class ETDDashServiceChecks():
             for filename in glob.glob('/home/etdadm/data/in/proquest*-999999-gsd'):  # noqa: E501
                 shutil.rmtree(filename)
 
-    def sftp_test_object(self):
+    def sftp_test_object(self, base_name):
         # proquest2dash test vars
         private_key = os.getenv("PRIVATE_KEY_PATH")
         remoteSite = os.getenv("dropboxServer")
@@ -163,10 +163,11 @@ class ETDDashServiceChecks():
         archiveDir = "archives/gsd"
         incomingDir = "incoming/gsd"
         zipFile = "submission_999999.zip"
+        newZipFile = "submission_" + base_name + ".zip"
         with pysftp.Connection(host=remoteSite,
                                username=remoteUser,
                                private_key=private_key) as sftp:
             if sftp.exists(f"{archiveDir}/{zipFile}"):
                 sftp.remove(f"{archiveDir}/{zipFile}")
                 sftp.put(f"./testdata/{zipFile}",
-                         f"{incomingDir}/{zipFile}")
+                         f"{incomingDir}/{newZipFile}")

--- a/app/tests/etd_dash_service_checks.py
+++ b/app/tests/etd_dash_service_checks.py
@@ -102,7 +102,7 @@ class ETDDashServiceChecks():
                 self.cleanup_test_object(base_name)
 
                 # 6. put the test object in the dropbox for a second time
-                # generate a random base name for the test object to make 
+                # generate a random base name for the test object to make
                 # duplicate detection more robust
                 base_name = ''.join(random.choices(string.digits, k=10))
                 dupe_dir = os.environ.get('ETD_DUPE_DIR')

--- a/app/tests/etd_dash_service_checks.py
+++ b/app/tests/etd_dash_service_checks.py
@@ -204,6 +204,12 @@ class ETDDashServiceChecks():
                                username=remoteUser,
                                private_key=private_key) as sftp:
             if sftp.exists(f"{archiveDir}/{zipFile}"):
-                sftp.remove(f"{archiveDir}/{zipFile}")
-                sftp.put(f"./testdata/{zipFile}",
-                         f"{incomingDir}/{newZipFile}")
+                try:
+                    sftp.remove(f"{archiveDir}/{zipFile}")
+                    sftp.put(f"./testdata/{zipFile}",
+                             f"{incomingDir}/{newZipFile}")
+                except Exception as err:
+                    logger.error(f"SFTP error: {err}")
+            # the file doesn't exist, log error.
+            else:
+                logger.error(f"{archiveDir}/{zipFile} does not exist.")

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -13,6 +13,7 @@ services:
     volumes:
       - './:/home/etdadm'
       - '/tmp/etd_dash_data/in:/home/etdadm/data/in'
+      - '/tmp/etd_dash_data/dupe:/home/etdadm/data/dupe'
       - './message.json:/home/etdadm/message.json'
     env_file:
       - './.env'

--- a/env-example.txt
+++ b/env-example.txt
@@ -1,5 +1,6 @@
 APP_VERSION=0.0.1
-APP_LOG_LEVEL=INFO
+APP_LOG_LEVEL=DEBUG
+LOG_DIR=/home/etdadm/logs
 
 # MongoDB info
 MONGO_URL=mongodb://USERNAME:PASSWORD@mongo-dev-1.lts.harvard.edu:27072,mongo-dev-2.lts.harvard.edu:27072,mongo-dev-arbiter.lts.harvard.edu:27072/?replicaSet=devrs&authSource=etdadm-dev
@@ -38,4 +39,3 @@ TEST_DATA_DIRECTORY=/home/etdadm/testdata
 ETD_IN_DIR=/etds/qa/etd_dash_data/in
 ETD_DUPE_DIR=/etds/qa/etd_dash_data/dupe
 DIMS_ENDPOINT=
-

--- a/env-example.txt
+++ b/env-example.txt
@@ -36,5 +36,6 @@ SUBMISSION_PQ_ID=
 
 TEST_DATA_DIRECTORY=/home/etdadm/testdata
 ETD_IN_DIR=/etds/qa/etd_dash_data/in
+ETD_DUPE_DIR=/etds/qa/etd_dash_data/dupe
 DIMS_ENDPOINT=
 


### PR DESCRIPTION
**Test `etd-dash-service` duplicate handling.**
* * *

**JIRA Ticket**: [ETD-285](https://at-harvard.atlassian.net/browse/ETD-285)

# What does this Pull Request do?
Test that duplicate submissions are moved to the `dupe/` directory. Also, centralize log creation and use throughout project.

# How should this be tested?
- Visual inspection
  - Integration test logic changes are in the `ETDDashServiceChecks` class, mostly in the `dash_deposit_test` method.
  - Please check the syntax I used for logging, especially the `self.logger` construct, as opposed to explicit variable declaration.
- Create a `trial` branch based on this branch, push to GIT, and wait for `trial` branch to pass CI/CD (https://ci.lib.harvard.edu/blue/organizations/jenkins/ETD%20Integration%20Tests/activity/)


# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? Yes

# Interested parties
@ives1227, @michael-lts, @cgoines 