### PR TITLE
ETD-332: add timestamp to alma export

### DIFF
--- a/app/tests/etd_alma_service_checks.py
+++ b/app/tests/etd_alma_service_checks.py
@@ -26,12 +26,12 @@ class ETDAlmaServiceChecks():
         DASH_FEATURE_FLAG = "dash_feature_flag"
         ALMA_FEATURE_FLAG = "alma_feature_flag"
 
-        yyyymmddhhmmss = get_date_time_stamp('second')
         instance = os.getenv('INSTANCE', '')
         if (instance == 'prod'):
             instance = ''
+        yyyymmddhhmm = get_date_time_stamp('minute')
         xmlCollectionFile = f'AlmaDeliveryTest{instance.capitalize()}' + \
-            f'_{yyyymmddhhmmss}.xml'
+            f'_{yyyymmddhhmm}.xml'
 
         client = Celery('app')
         client.config_from_object('celeryconfig')

--- a/app/tests/etd_alma_service_checks.py
+++ b/app/tests/etd_alma_service_checks.py
@@ -27,7 +27,7 @@ class ETDAlmaServiceChecks():
         ALMA_FEATURE_FLAG = "alma_feature_flag"
 
         yyyymmddhhmmss = get_date_time_stamp('second')
-        instance = os.getenv('INSTANCE')
+        instance = os.getenv('INSTANCE', 'prod')
         xmlCollectionFile = f'AlmaDeliveryTest_{instance}_{yyyymmddhhmmss}.xml'
 
         client = Celery('app')

--- a/app/tests/etd_alma_service_checks.py
+++ b/app/tests/etd_alma_service_checks.py
@@ -26,8 +26,9 @@ class ETDAlmaServiceChecks():
         DASH_FEATURE_FLAG = "dash_feature_flag"
         ALMA_FEATURE_FLAG = "alma_feature_flag"
 
-        yyyymmdd = get_date_time_stamp('day')
-        xmlCollectionFile = f'AlmaDeliveryTest_{yyyymmdd}.xml'
+        yyyymmddhhmmss = get_date_time_stamp('second')
+        instance = os.getenv('INSTANCE')
+        xmlCollectionFile = f'AlmaDeliveryTest_{instance}_{yyyymmddhhmmss}.xml'
 
         client = Celery('app')
         client.config_from_object('celeryconfig')

--- a/app/tests/etd_alma_service_checks.py
+++ b/app/tests/etd_alma_service_checks.py
@@ -27,8 +27,11 @@ class ETDAlmaServiceChecks():
         ALMA_FEATURE_FLAG = "alma_feature_flag"
 
         yyyymmddhhmmss = get_date_time_stamp('second')
-        instance = os.getenv('INSTANCE', 'prod')
-        xmlCollectionFile = f'AlmaDeliveryTest_{instance}_{yyyymmddhhmmss}.xml'
+        instance = os.getenv('INSTANCE', '')
+        if (instance == 'prod'):
+            instance = ''
+        xmlCollectionFile = f'AlmaDeliveryTest{instance.capitalize()}' + \
+            f'_{yyyymmddhhmmss}.xml'
 
         client = Celery('app')
         client.config_from_object('celeryconfig')

--- a/env-example.txt
+++ b/env-example.txt
@@ -50,3 +50,5 @@ ALMA_BATCH_NAME=
 ALMA_MESSAGE_FILE=alma_message.json
 
 ALMA_MONITOR_SERVICE_QUEUE_NAME=in_alma_dropbox
+
+INSTANCE=dev


### PR DESCRIPTION
**add timestamp to alma export.**
* * *

**JIRA Ticket**: https://at-harvard.atlassian.net/browse/ETD-332

# What does this Pull Request do?
add timestamp to alma export.

# How should this be tested?
1) download branch
2) get `alma_proquest_id_rsa` &` known_hosts` from vault and put in `.ssh/`
3) copy env-example to .env and set to dev settings, ensure mongo values are set
4) start container `docker-compose -f docker-compose-local.yml up -d --build --force-recreate`
5) https://localhost:10610/alma_service   It should pass
6) go into the alma dropbox by typing `sftp -i .ssh/alma_dropbox_id_rsa huletd@hegel`.  cd to `incoming` and then do an ls. you should see a file in the format `AlmaDeliveryTestDev_<DATETIMESTAMP>.xml`
7) shutdown container `docker-compose -f docker-compose-local.yml down`


# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n
- integration tests? y

# Interested parties
Tag (@ mention) interested parties: @awoods 
