### PR TITLE
ETD-281: productionize logging

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,15 +1,18 @@
 import os
-import click
 import logging
-import traceback
+import socket
+from datetime import datetime
 from logging.handlers import TimedRotatingFileHandler
-from flask import Flask, current_app
+from flask import Flask
 # Import custom modules from the local project
 # Import API resources
 from . import resources
 
 LOG_FILE_BACKUP_COUNT = 1
 LOG_ROTATION = "midnight"
+
+container_id = socket.gethostname()
+timestamp = datetime.today().strftime('%Y-%m-%d')
 
 
 # App factory
@@ -31,18 +34,24 @@ def create_app():
 
 def configure_logger():
     log_level = os.getenv("APP_LOG_LEVEL", "INFO")
-    log_dir = os.getenv("LOG_DIR", "/home/etdadm/logs/etd_itest")
-    log_file_path = os.path.join(log_dir, "int_tests.log")
+    log_file_path = os.getenv("LOG_DIR", "/home/etdadm/logs/etd_itest")
     formatter = logging.Formatter(
-        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+                '%(asctime)s - %(name)s - %(levelname)s - ' +
+                '[%(filename)s:%(funcName)s:%(lineno)d] - %(message)s')
 
-    file_handler = TimedRotatingFileHandler(
-        filename=log_file_path,
-        when=LOG_ROTATION,
-        backupCount=LOG_FILE_BACKUP_COUNT
-    )
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
 
     logger = logging.getLogger('etd_int_tests')
-    logger.addHandler(file_handler)
-    file_handler.setFormatter(formatter)
+    logger.addHandler(console_handler)
+    # Defaults to console logging
+    if os.getenv("CONSOLE_LOGGING_ONLY", "true") == "false":
+        file_handler = TimedRotatingFileHandler(
+            filename=f"{log_file_path}/{container_id}_console_{timestamp}.log",
+            when=LOG_ROTATION,
+            backupCount=LOG_FILE_BACKUP_COUNT
+        )
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
+
     logger.setLevel(log_level)


### PR DESCRIPTION
**productionize logging**
* * *

**JIRA Ticket**: https://at-harvard.atlassian.net/browse/ETD-281

# What does this Pull Request do?
adds filename and line number info to logs

# How should this be tested?
this has been moved to dev.
to test:

1) enter the container on cloud dev, `cd logs/etd_itest; ls -lat | head -5` to find the running log (it should be at the top), then` tail -f ~/logs/etd_itest/<CONTAINER_ID>_supervisord_worker_stderr.log`
2) point your browser or curl at: https://ltsds-cloud-dev-1.lib.harvard.edu:10610/alma_service . You should get this json message `{"num_failed": 0, "tests_failed": [], "info": {}}` confirming no errors.
3) tail should show output similar to this:

```
2023-12-14 21:18:22,800 - etd_int_tests - INFO - [etd_alma_service_checks.py:alma_service_test:18] - >>> Starting alma service integration test
2023-12-14 21:18:22,828 - etd_int_tests - INFO - [etd_alma_service_checks.py:alma_service_test:39] - >>> Read message file
2023-12-14 21:18:22,831 - etd_int_tests - INFO - [etd_alma_service_checks.py:alma_service_test:56] - >>> Cleanup test object
2023-12-14 21:18:22,833 - etd_int_tests - INFO - [etd_alma_service_checks.py:alma_service_test:60] - >>> Setup test object
2023-12-14 21:18:22,847 - etd_int_tests - INFO - [etd_alma_service_checks.py:alma_service_test:64] - >>> Submit test object to alma
2023-12-14 21:18:25,434 - etd_int_tests - INFO - [etd_alma_service_checks.py:alma_service_test:72] - >>> SFTP check Alma export
2023-12-14 21:18:26,165 - etd_int_tests - INFO - [etd_alma_service_checks.py:alma_service_test:92] - >>> Cleanup test object
```

if you see something similar w/ current timestamps, then the test worked.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n
- integration tests? n

# Interested parties
Tag (@ mention) interested parties: @awoods 
