### PR TITLE
Test archiving of duplicate submissions to dupe/ directory.

### DIFF
--- a/app/tests/etd_dash_service_checks.py
+++ b/app/tests/etd_dash_service_checks.py
@@ -231,6 +231,13 @@ class ETDDashServiceChecks():
                                            "text": "Delete failed"}}
                         self.logger.error("Delete failed: " + response.text)
 
+                # verify that the test object is no longer in dash
+                self.verify_submission_count(
+                    0,
+                    "DASH_OBJECT_NOT_DELETED",
+                    "Test object not deleted from dash",
+                    result)
+    
                 # cleanup the test object from the filesystem
                 self.logger.info(">>> Clean up duplicate test object, again.")
                 self.cleanup_test_object(base_name)

--- a/app/tests/etd_dash_service_checks.py
+++ b/app/tests/etd_dash_service_checks.py
@@ -237,7 +237,7 @@ class ETDDashServiceChecks():
                     "DASH_OBJECT_NOT_DELETED",
                     "Test object not deleted from dash",
                     result)
-    
+
                 # cleanup the test object from the filesystem
                 self.logger.info(">>> Clean up duplicate test object, again.")
                 self.cleanup_test_object(base_name)

--- a/app/tests/etd_dash_service_checks.py
+++ b/app/tests/etd_dash_service_checks.py
@@ -312,6 +312,26 @@ class ETDDashServiceChecks():
             except Exception as err:
                 self.logger.error(f"SFTP error: {err}")
 
+    def sftp_check_for_dupe(self, base_name):
+        # proquest2dash test vars
+        private_key = os.getenv("PRIVATE_KEY_PATH")
+        remoteSite = os.getenv("dropboxServer")
+        remoteUser = os.getenv("dropboxUser")
+        dupe_dir = "dupe/gsd"
+        file_pattern = re.compile(r'^submission_' + base_name
+                                  + r'_\d{14}\.zip$')
+        with pysftp.Connection(host=remoteSite,
+                               username=remoteUser,
+                               private_key=private_key) as sftp:
+            # List files in the remote directory
+            files = sftp.listdir(dupe_dir)
+            # Check if any file matches the specified pattern
+            for file_name in files:
+                if file_pattern.match(file_name):
+                    return True  # File with the pattern exists
+
+        return False  # No file with the pattern found
+
     # Method to return a random string of 10 digits
     def random_digit_string(self):
         return ''.join(random.choices(string.digits, k=10))

--- a/app/tests/etd_dash_service_checks.py
+++ b/app/tests/etd_dash_service_checks.py
@@ -183,6 +183,22 @@ class ETDDashServiceChecks():
                 self.logger.info(">>> Clean up duplicate test object")
                 self.cleanup_test_object(base_name)
 
+                # 12. Test that duplicate submission is moved to the dupe dir.
+                # Upload the test object one more time, using the same name
+                # as before. This time it should be moved to the dupe dir
+                # on the dropbox, instead of the archive dir (because it's
+                # already in the archive dir).
+                try:
+                    self.logger.info(">>> SFTP duplicate test object, again")
+                    self.sftp_test_object(base_name)
+                except Exception as err:
+                    result["num_failed"] += 1
+                    result["tests_failed"].append("SFTP")
+                    result["info"] = {"Proquest Dropbox sftp failed":
+                                      {"status_code": 500,
+                                       "text": str(err)}}
+                    self.logger.error(str(err))
+
             else:
                 client.send_task(name="etd-dash-service.tasks.send_to_dash",
                                  args=[message], kwargs={},

--- a/app/tests/etd_dash_service_checks.py
+++ b/app/tests/etd_dash_service_checks.py
@@ -9,6 +9,7 @@ import requests
 import random
 import string
 import logging
+import re
 
 
 class ETDDashServiceChecks():
@@ -204,10 +205,16 @@ class ETDDashServiceChecks():
                                  queue=incoming_queue)
                 time.sleep(sleep_secs)  # wait for queue
 
-                client.send_task(name="etd-dash-service.tasks.send_to_dash",
-                                 args=[message], kwargs={},
-                                 queue=incoming_queue)
-                time.sleep(sleep_secs)  # wait for queue
+                # make sure the submission file is in the dupe dir
+                if not self.sftp_check_for_dupe(base_name):
+                    result["num_failed"] += 1
+                    result["tests_failed"].append("DASH_DUPE")
+                    result["info"] = {("DASH archive to dupe dropbox "
+                                      "directory failed"):
+                                      {"status_code": 500,
+                                       "text":
+                                       "Dupe dropbox directory not found."
+                                       }}
 
                 # 13. cleanup the test object from the filesystem, again.
                 self.logger.info((">>> Delete duplicate test object "


### PR DESCRIPTION
**Test archiving of duplicate submissions to dupe/ directory.**
* * *

**JIRA Ticket**: [ETD-352](https://at-harvard.atlassian.net/browse/ETD-352)

# What does this Pull Request do?
Adds a test where a duplicate submission with the exact same name as a previous submission is shown to be moved to the duplicate directory.

# How should this be tested?
- Convert to trial branch and make sure it successfully finishes integration testing. 
- After it runs in dev, you should see a copy of the submission file in the archives directory and another copy in the dupe directory. The version in the dupe dir will have a timestamp appended. For example:

> -bash-4.2$ hostname
> hegel.lib.harvard.edu
> -bash-4.2$ ll -t `find archives/ -type f` | more
> -rw-r--r-- 1 proquest guestftp  12999084 Dec 20 14:22 archives/gsd/submission_4839259672.zip
> -bash-4.2$ ll -t `find dupe/ -type f` | more
> -rw-r--r-- 1 proquest guestftp 12999084 Dec 20 14:22 dupe/gsd/submission_4839259672_20231220192238.zip


# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? Yes.

# Interested parties
@michael-lts, @ives1227 
