### PR TITLE
Etd 320

### DIFF
--- a/app/resources.py
+++ b/app/resources.py
@@ -82,15 +82,24 @@ def define_resources(app):
         # been updated in the services yet.
         res1 = connectivity()
         res2 = etd_dash_service_testing()
+        res3 = etd_alma_service_testing()
+        res4 = etd_alma_monitor_service_testing()
         res1_json = json.loads(res1)
         res2_json = json.loads(res2)
+        res3_json = json.loads(res3)
+        res4_json = json.loads(res4)
         result["num_failed"] = res1_json["num_failed"] \
-            + res2_json["num_failed"]
+            + res2_json["num_failed"] + res3_json["num_failed"]
         if len(res1_json["tests_failed"]) > 0:
             result["tests_failed"].append(res1_json["tests_failed"])
         if len(res2_json["tests_failed"]) > 0:
             result["tests_failed"].append(res2_json["tests_failed"])
-        result["info"] = result["info"] | res1_json["info"] | res2_json["info"]
+        if len(res3_json["tests_failed"]) > 0:
+            result["tests_failed"].append(res3_json["tests_failed"])
+        if len(res4_json["tests_failed"]) > 0:
+            result["tests_failed"].append(res4_json["tests_failed"])
+        result["info"] = result["info"] | res1_json["info"] | \
+            res2_json["info"] | res3_json["info"]
 
         return json.dumps(result)
 

--- a/app/resources.py
+++ b/app/resources.py
@@ -82,12 +82,10 @@ def define_resources(app):
         # been updated in the services yet.
         res1 = connectivity()
         res2 = etd_dash_service_testing()
-        res3 = etd_alma_service_testing()
-        res4 = etd_alma_monitor_service_testing()
+        res3 = etd_alma_monitor_service_testing()
         res1_json = json.loads(res1)
         res2_json = json.loads(res2)
         res3_json = json.loads(res3)
-        res4_json = json.loads(res4)
         result["num_failed"] = res1_json["num_failed"] \
             + res2_json["num_failed"] + res3_json["num_failed"]
         if len(res1_json["tests_failed"]) > 0:
@@ -96,8 +94,6 @@ def define_resources(app):
             result["tests_failed"].append(res2_json["tests_failed"])
         if len(res3_json["tests_failed"]) > 0:
             result["tests_failed"].append(res3_json["tests_failed"])
-        if len(res4_json["tests_failed"]) > 0:
-            result["tests_failed"].append(res4_json["tests_failed"])
         result["info"] = result["info"] | res1_json["info"] | \
             res2_json["info"] | res3_json["info"]
 

--- a/app/tests/etd_alma_monitor_service_checks.py
+++ b/app/tests/etd_alma_monitor_service_checks.py
@@ -112,6 +112,8 @@ class ETDAlmaMonitorServiceChecks():
             mongo_client = MongoClient(mongo_url, maxPoolSize=1)
             mongo_db = mongo_client[os.getenv("MONGO_DBNAME")]
             collection = mongo_db[os.getenv("MONGO_COLLECTION")]
+            # clean up any previous test runs
+            collection.delete_many({"proquest_id": known_pq_id})
             collection.insert_one(record)
             mongo_client.close()
         except Exception as err:


### PR DESCRIPTION
**Add the alma monitor testing to /integation endpoint.**
* * *

**JIRA Ticket**: [(link)](https://at-harvard.atlassian.net/browse/ETD-320)

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
This pr adds the alma_monitor endpoint to the /integration endpoint. This means we have testing for all 4 components (along with "/connectivity") because etd dash calls etd alma by message, then separately alma monitor calls drs holdings by message

# How should this be tested?

Deploy to dev (done)
run the integration test:
https://ltsds-cloud-dev-1.lib.harvard.edu:10610/integration
Tests should pass

run dev tracing:
http://ltsds-cloud-dev-1.lib.harvard.edu:16686/
Search by "identifier=30522803" in Tags
You should see 3 "ETD: Initialized Pipeline" (2 with 9 traces, 1 with 4) and 1 "ETD: Initialized ALMA Monnitor / DRS"
Note there are some known errors which are in separate subtasks for the jira above


# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests?
- integration tests?

# Interested parties
Tag (@ mention) interested parties
