### PR TITLE
Int test for non DASH submissions

### DIFF
--- a/app/resources.py
+++ b/app/resources.py
@@ -214,7 +214,7 @@ def define_resources(app):
         result["info"] = result["info"] | end_to_end_result["info"]
 
         return json.dumps(result)
-    
+
     @app.route('/etd_end_to_end_no_dash')
     def etd_end_to_end_no_dash():
         result = {"num_failed": 0,

--- a/app/resources.py
+++ b/app/resources.py
@@ -214,3 +214,18 @@ def define_resources(app):
         result["info"] = result["info"] | end_to_end_result["info"]
 
         return json.dumps(result)
+    
+    @app.route('/etd_end_to_end_no_dash')
+    def etd_end_to_end_no_dash():
+        result = {"num_failed": 0,
+                  "tests_failed": [], "info": {}}
+
+        etd_end_to_end = ETDEndToEnd()
+        end_to_end_result = etd_end_to_end \
+            .end_to_end(False)
+        result["num_failed"] = end_to_end_result["num_failed"]
+        if len(end_to_end_result["tests_failed"]) > 0:
+            result["tests_failed"].append(end_to_end_result["tests_failed"])
+        result["info"] = result["info"] | end_to_end_result["info"]
+
+        return json.dumps(result)

--- a/app/tests/etd_end_to_end.py
+++ b/app/tests/etd_end_to_end.py
@@ -48,9 +48,11 @@ class ETDEndToEnd():
 
         # If the test object is for indash, use this one
         zipFile = "submission_999999.zip"
+        schoolcode = "gsd"
         # Otherwise use the non-dash one
         if not indash:
             zipFile = "submission_no_dash.zip"
+            schoolcode = "college"
         newZipFile = "submission_" + base_name + ".zip"
         shutil.copyfile(f"./testdata/{zipFile}", f"./testdata/{newZipFile}")
 
@@ -58,7 +60,7 @@ class ETDEndToEnd():
         # put the test object in the dropbox
         self.logger.info(">>> SFTP test object")
         try:
-            self.sftp_test_object(newZipFile)
+            self.sftp_test_object(newZipFile, schoolcode)
         except Exception as err:
             result["num_failed"] += 1
             result["tests_failed"].append("SFTP")
@@ -102,20 +104,21 @@ class ETDEndToEnd():
         resp = requests.post(login_url, data=login_info, verify=False)
         return resp.cookies.get('JSESSIONID')
 
-    def cleanup_test_object(self, base_name):
-        if glob.glob('/home/etdadm/data/in/proquest*-' + base_name + '-gsd/submission_' + base_name + '.zip'):  # noqa: E501
-            for filename in glob.glob('/home/etdadm/data/in/proquest*-' + base_name + '-gsd/*'):  # noqa: E501
+    def cleanup_test_object(self, base_name, schoolcode="gsd"):
+        dirname = 'proquest*-' + base_name + '-' + schoolcode
+        if glob.glob('/home/etdadm/data/in/' + dirname + '/submission_' + base_name + '.zip'):  # noqa: E501
+            for filename in glob.glob('/home/etdadm/data/in/' + dirname + '/*'):  # noqa: E501
                 os.remove(filename)
-            for filename in glob.glob('/home/etdadm/data/in/proquest*-' + base_name + '-gsd'):  # noqa: E501
+            for filename in glob.glob('/home/etdadm/data/in/' + dirname):  # noqa: E501
                 shutil.rmtree(filename)
 
-    def sftp_test_object(self, submission_zip_object):
+    def sftp_test_object(self, submission_zip_object, schoolcode="gsd"):
         # proquest2dash test vars
         private_key = os.getenv("PRIVATE_KEY_PATH")
         remoteSite = os.getenv("dropboxServer")
         remoteUser = os.getenv("dropboxUser")
-        archiveDir = "archives/gsd"
-        incomingDir = "incoming/gsd"
+        archiveDir = "archives/" + schoolcode
+        incomingDir = "incoming/" + schoolcode
         self.logger.debug(">>> Test object name: {}".
                           format(submission_zip_object))
         with pysftp.Connection(host=remoteSite,

--- a/app/tests/etd_end_to_end.py
+++ b/app/tests/etd_end_to_end.py
@@ -17,7 +17,23 @@ class ETDEndToEnd():
     def __init__(self):
         self.logger = logging.getLogger('etd_int_tests')
 
-    def end_to_end(self):
+    def end_to_end(self, indash=True):
+        """
+            Executes the end-to-end integration test.
+
+            Args:
+                indash (bool, optional): Flag indicating whether to
+                this is an indash test.
+                    Defaults to True.
+
+            Returns:
+                dict: A dictionary containing the test result with the
+                following keys:
+                    - num_failed (int): The number of failed tests.
+                    - tests_failed (list): A list of failed test names.
+                    - info (dict): Additional information about the
+                    test result.
+        """
         self.logger.info(">>> Starting integration test")
         result = {"num_failed": 0,
                   "tests_failed": [],
@@ -30,7 +46,11 @@ class ETDEndToEnd():
 
         base_name = self.random_digit_string()
 
+        # If the test object is for indash, use this one
         zipFile = "submission_999999.zip"
+        # Otherwise use the non-dash one
+        if not indash:
+            zipFile = "submission_no_dash.zip"
         newZipFile = "submission_" + base_name + ".zip"
         shutil.copyfile(f"./testdata/{zipFile}", f"./testdata/{newZipFile}")
 


### PR DESCRIPTION
**Int test for non DASH submissions**
* * *

**JIRA Ticket**: https://at-harvard.atlassian.net/browse/ETD-360


# How should this be tested?

Submit a sample nonDASH submission via the integration test: https://ltsds-cloud-dev-1.lib.harvard.edu:10610/etd_end_to_end_no_dash and verify that an empty that an Alma entry gets created without a DASH entry (done) 
This can be done by clicking the link and asking Paul A to ingest the MARCXML into Alma QA once it gets synced by Tim's script.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? no
- integration tests? yes - this is an int test

