### PR TITLE
Dash test fix

### DIFF
--- a/app/tests/etd_dash_service_checks.py
+++ b/app/tests/etd_dash_service_checks.py
@@ -310,9 +310,11 @@ class ETDDashServiceChecks():
                 sftp.put(f"./testdata/{zipFile}",
                          f"{incomingDir}/{newZipFile}")
                 if sftp.exists(f"{incomingDir}/{newZipFile}"):
-                    self.logger.info(f"Test object sftp'd to {incomingDir}")
+                    self.logger.info(f"Test object sftp'd to \
+                                     {incomingDir}/{newZipFile}")
                 else:
-                    raise Exception(f"Test object not sftp'd to {incomingDir}")
+                    raise Exception(f"Test object not sftp'd to \
+                                    {incomingDir}/{newZipFile}")
             except Exception as err:
                 self.logger.error(f"SFTP error: {err}")
 

--- a/app/tests/etd_dash_service_checks.py
+++ b/app/tests/etd_dash_service_checks.py
@@ -258,8 +258,8 @@ class ETDDashServiceChecks():
                     self.logger.info("Test object sftp'd to "
                                      f"{incomingDir}/{newZipFile}")
                 else:
-                    raise Exception(f"Test object not sftp'd to \
-                                    {incomingDir}/{newZipFile}")
+                    raise Exception("Test object not sftp'd to "
+                                    f"{incomingDir}/{newZipFile}")
             except Exception as err:
                 self.logger.error(f"SFTP error: {err}")
 

--- a/app/tests/etd_dash_service_checks.py
+++ b/app/tests/etd_dash_service_checks.py
@@ -309,6 +309,10 @@ class ETDDashServiceChecks():
             try:
                 sftp.put(f"./testdata/{zipFile}",
                          f"{incomingDir}/{newZipFile}")
+                if sftp.exists(f"{incomingDir}/{newZipFile}"):
+                    self.logger.info(f"Test object sftp'd to {incomingDir}")
+                else:
+                    raise Exception(f"Test object not sftp'd to {incomingDir}")
             except Exception as err:
                 self.logger.error(f"SFTP error: {err}")
 


### PR DESCRIPTION
**Fix Dash submission test.**
* * *

**JIRA Ticket**: [ETD-382](https://at-harvard.atlassian.net/browse/ETD-382)

# What does this Pull Request do?
Integration tests were failing in dev and QA. There was an issue with the initial deposit to Dash being treated as a duplicate, resulting in downstream errors. At the end of testing, all objects submitted to Dash are deleted by `etd-integration-tests`. The integration tests assume that test objects are not in Dash at the beginning of the test. It seems as though there was a previous failure in the tests that left test object(s) in Dash, causing problems in future tests runs. 

This PR addresses this type of failure by clearing any test object from Dash that maybe remain from a previous test. It also refactors the code that implements the delete, because it's called from multiple places. 

# How should this be tested?
- Visual inspection
- Build locally
- (Optional) Push through as trial branch.

# Test coverage
Yes/No:  Yes
- unit tests? No
- integration tests? Yes

# Interested parties
@ives1227, @michael-lts, @cgoines 

[ETD-382]: https://at-harvard.atlassian.net/browse/ETD-382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ